### PR TITLE
Add meta-virtualization layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ As the Yocto Project is based on the concept of [layers](https://docs.yoctoproje
 | meta-chargebyte | BSP layer for Tarragon | https://github.com/chargebyte/meta-chargebyte |
 | meta-chargebyte-distro | Distribution adaptations layer | https://github.com/chargebyte/meta-chargebyte-distro |
 | meta-freescale | Layer containing NXP hardware support metadata | https://git.yoctoproject.org/cgit/cgit.cgi/meta-freescale |
+| meta-virtualization | Layer containing additional packages | https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization |
 | meta-openembedded | Collection of layers to supplement OE-Core with additional packages | https://github.com/openembedded/meta-openembedded |
 | meta-rauc| Layer controlling and performing secure software updates for embedded Linux | https://github.com/rauc/meta-rauc |
 | meta-everest | Layer containing EVerest charging stack | https://github.com/EVerest/meta-everest |
@@ -64,6 +65,7 @@ This "wrapper" repository has been created to facilitate downloading the above-m
   <!-- project definitions -->
   <project remote="yocto"        revision="kirkstone"                                name="poky"                    path="source"/>
   <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"          path="source/meta-freescale"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-virtualization"     path="source/meta-virtualization"/>
   <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"       path="source/meta-openembedded"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"         path="source/meta-chargebyte"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"  path="source/meta-chargebyte-distro"/>

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -16,6 +16,7 @@ BBLAYERS ?= " \
   ${BSPDIR}/meta-openembedded/meta-networking \
   ${BSPDIR}/meta-openembedded/meta-filesystems \
   ${BSPDIR}/meta-openembedded/meta-multimedia \
+  ${BSPDIR}/meta-virtualization \
   ${BSPDIR}/meta-rauc \
   ${BSPDIR}/meta-chargebyte \
   ${BSPDIR}/meta-chargebyte-distro \

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -230,6 +230,10 @@ CONF_VERSION = "2"
 
 ACCEPT_FSL_EULA = "1"
 
+# we are only interested in some tools, so let's disable the warning
+# (see readme in meta-virtualization for details)
+SKIP_META_VIRT_SANITY_CHECK = "1"
+
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -269,6 +269,9 @@ IMAGE_FSTYPES = "ext4 ext4.gz"
 EXTRA_IMAGECMD:ext4 = "-b 4096 -J size=32 -O ^metadata_csum"
 IMAGE_ROOTFS_SIZE = "262144"
 
+# Note: for developer images we need a smaller overhead in order to fit into the 1GB rootfs
+IMAGE_OVERHEAD_FACTOR = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'debug-tweaks', '1.1', '1.3', d)}"
+
 #
 # turn 'version-going-backwards' errors into warnings only since we use several git repos
 #

--- a/default.xml
+++ b/default.xml
@@ -12,6 +12,7 @@
   <!-- project definitions -->
   <project remote="yocto"        revision="kirkstone"                                name="poky"                    path="source"/>
   <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"          path="source/meta-freescale"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-virtualization"     path="source/meta-virtualization"/>
   <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"       path="source/meta-openembedded"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"         path="source/meta-chargebyte"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"  path="source/meta-chargebyte-distro"/>


### PR DESCRIPTION
This layer includes the handy tool yq which can be useful when working with EVerest's YAML files.

At the moment, we don't want to use virtualization on our embedded platforms, so we disable a warning reminder that virtualization should usually also be added to the DISTRO_FEATURES.