### PR TITLE
Add initial support for upcoming Charge SOM platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ As the Yocto Project is based on the concept of [layers](https://docs.yoctoproje
 
 | Layer | Description | Repository |
 |--|--|--|
-| meta-chargebyte | BSP layer for EVAcharge SE, Tarragon & Charge SOM | https://github.com/chargebyte/meta-chargebyte |
-| meta-chargebyte-distro | Distribution adaptations layer | https://github.com/chargebyte/meta-chargebyte-distro |
+| poky | Build tool and metadata included in a reference distribution | https://git.yoctoproject.org/poky |
 | meta-freescale | Layer containing NXP hardware support metadata | https://git.yoctoproject.org/cgit/cgit.cgi/meta-freescale |
 | meta-openembedded | Collection of layers to supplement OE-Core with additional packages | https://github.com/openembedded/meta-openembedded |
+| meta-security | Collection of security-related layers e.g. for TPM support | https://git.yoctoproject.org/meta-security |
 | meta-rauc| Layer controlling and performing secure software updates for embedded Linux | https://github.com/rauc/meta-rauc |
-| poky | Build tool and metadata included in a reference distribution | https://git.yoctoproject.org/poky |
+| meta-chargebyte | BSP layer for EVAcharge SE, Tarragon & Charge SOM | https://github.com/chargebyte/meta-chargebyte |
+| meta-chargebyte-distro | Distribution adaptations layer | https://github.com/chargebyte/meta-chargebyte-distro |
 
 This layering approach increases flexibility to expand your project. You can add layers, which in turn would add packages essential for the distribution you want to build. Layers are usually available as repositories. Information on how to include or remove layers will be given in [Section 3.3](#addorremove). Note that no charging capabilities will be included in the Linux distribution created by this setup.
 
@@ -61,6 +62,7 @@ This "wrapper" repository has been created to facilitate downloading the above-m
   <project remote="yocto"        revision="kirkstone"                                name="poky"                   path="source"/>
   <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"         path="source/meta-freescale"/>
   <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"      path="source/meta-openembedded"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-security"          path="source/meta-security"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"        path="source/meta-chargebyte"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro" path="source/meta-chargebyte-distro"/>
   <project remote="rauc"         revision="kirkstone"                                name="meta-rauc"              path="source/meta-rauc"/>

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -16,6 +16,7 @@ BBLAYERS ?= " \
   ${BSPDIR}/meta-openembedded/meta-networking \
   ${BSPDIR}/meta-openembedded/meta-filesystems \
   ${BSPDIR}/meta-openembedded/meta-multimedia \
+  ${BSPDIR}/meta-security/meta-tpm \
   ${BSPDIR}/meta-rauc \
   ${BSPDIR}/meta-chargebyte \
   ${BSPDIR}/meta-chargebyte-distro \

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -12,9 +12,16 @@
 PROJECT ?= "bsp"
 
 #
-# Machine selection: "evachargese", "tarragon"
+# Machine selection: "evachargese", "tarragon", "chargesom"
 #
 MACHINE ?= "tarragon"
+
+#
+# Submachine selection, depends on selected MACHINE.
+# Valid values: e.g. for "chargesom": "dc-evb"
+# Must be empty otherwise.
+#
+SUBMACHINE ?= ""
 
 #
 # List of additional packages to include in this build

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -237,6 +237,10 @@ CONF_VERSION = "2"
 
 ACCEPT_FSL_EULA = "1"
 
+# we are only interested in some tools, so let's disable the warning
+# (see readme in meta-tpm for details)
+SKIP_META_TPM_SANITY_CHECK = "1"
+
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 

--- a/default.xml
+++ b/default.xml
@@ -12,6 +12,7 @@
   <project remote="yocto"        revision="kirkstone"                                name="poky"                    path="source"/>
   <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"          path="source/meta-freescale"/>
   <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"       path="source/meta-openembedded"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-security"           path="source/meta-security"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"         path="source/meta-chargebyte"/>
   <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"  path="source/meta-chargebyte-distro"/>
   <project remote="rauc"         revision="kirkstone"                                name="meta-rauc"               path="source/meta-rauc"/>

--- a/default.xml
+++ b/default.xml
@@ -3,7 +3,7 @@
   <default sync-j="4" revision="kirkstone"/>
 
   <!-- remote repository definitions -->
-  <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
+  <remote fetch="https://git.yoctoproject.org" name="yocto"/>
   <remote fetch="https://github.com/openembedded" name="oe"/>
   <remote fetch="https://github.com/chargebyte" name="chargebyte"/>
   <remote fetch="https://github.com/rauc" name="rauc"/>

--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <default sync-j="4" revision="master"/>
+  <default sync-j="4" revision="kirkstone"/>
 
   <!-- remote repository definitions -->
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>


### PR DESCRIPTION
This PR mentions the upcoming Charge SOM platform in the documentation and adds the required Yocto layer for TPM support.

While at, two small maintainance fixes are included.