### PR TITLE
Add meta-layers for Qt5 and nymea.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,27 @@ This "wrapper" repository has been created to facilitate downloading the above-m
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <default sync-j="4" revision="master"/>
+  <default sync-j="4" revision="kirkstone"/>
 
   <!-- remote repository definitions -->
-  <remote fetch="https://git.yoctoproject.org/git" name="yocto"/><!-- This represents a link to a repository, and it will have a name for further usage -->
+  <remote fetch="https://git.yoctoproject.org" name="yocto"/>
   <remote fetch="https://github.com/openembedded" name="oe"/>
   <remote fetch="https://github.com/chargebyte" name="chargebyte"/>
   <remote fetch="https://github.com/rauc" name="rauc"/>
+  <remote fetch="https://github.com/meta-qt5" name="qt5"/>
+  <remote fetch="https://github.com/nymea" name="nymea"/>
 
   <!-- project definitions -->
-  <project remote="yocto"        revision="kirkstone"                                name="poky"                   path="source"/>
-  <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"         path="source/meta-freescale"/>
-  <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"      path="source/meta-openembedded"/>
-  <project remote="yocto"        revision="kirkstone"                                name="meta-security"          path="source/meta-security"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"        path="source/meta-chargebyte"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro" path="source/meta-chargebyte-distro"/>
-  <project remote="rauc"         revision="kirkstone"                                name="meta-rauc"              path="source/meta-rauc"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="chargebyte-bsp"         path="chargebyte-bsp">
+  <project remote="yocto"        revision="kirkstone"                                name="poky"                     path="source"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"           path="source/meta-freescale"/>
+  <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"        path="source/meta-openembedded"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-security"            path="source/meta-security"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"          path="source/meta-chargebyte"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"   path="source/meta-chargebyte-distro"/>
+  <project remote="rauc"         revision="2eb0d2af94c63f4bc5b52e5f7c5a36000bfd7016" name="meta-rauc"                path="source/meta-rauc"/>
+  <project remote="qt5"          revision="kirkstone"                                name="meta-qt5"                 path="source/meta-qt5"/>
+  <project remote="nymea"        revision="kirkstone"                                name="meta-nymea"               path="source/meta-nymea"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="chargebyte-bsp"           path="chargebyte-bsp">
     <linkfile dest="build/conf" src="conf"/>
   </project>
 

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -18,6 +18,8 @@ BBLAYERS ?= " \
   ${BSPDIR}/meta-openembedded/meta-multimedia \
   ${BSPDIR}/meta-security/meta-tpm \
   ${BSPDIR}/meta-rauc \
+  ${BSPDIR}/meta-qt5 \
+  ${BSPDIR}/meta-nymea \
   ${BSPDIR}/meta-chargebyte \
   ${BSPDIR}/meta-chargebyte-distro \
 "

--- a/default.xml
+++ b/default.xml
@@ -7,16 +7,20 @@
   <remote fetch="https://github.com/openembedded" name="oe"/>
   <remote fetch="https://github.com/chargebyte" name="chargebyte"/>
   <remote fetch="https://github.com/rauc" name="rauc"/>
+  <remote fetch="https://github.com/meta-qt5" name="qt5"/>
+  <remote fetch="https://github.com/nymea" name="nymea"/>
 
   <!-- project definitions -->
-  <project remote="yocto"        revision="kirkstone"                                name="poky"                    path="source"/>
-  <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"          path="source/meta-freescale"/>
-  <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"       path="source/meta-openembedded"/>
-  <project remote="yocto"        revision="kirkstone"                                name="meta-security"           path="source/meta-security"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"         path="source/meta-chargebyte"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"  path="source/meta-chargebyte-distro"/>
-  <project remote="rauc"         revision="2eb0d2af94c63f4bc5b52e5f7c5a36000bfd7016" name="meta-rauc"               path="source/meta-rauc"/>
-  <project remote="chargebyte"   revision="kirkstone"                                name="chargebyte-bsp"          path="chargebyte-bsp">
+  <project remote="yocto"        revision="kirkstone"                                name="poky"                     path="source"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-freescale"           path="source/meta-freescale"/>
+  <project remote="oe"           revision="kirkstone"                                name="meta-openembedded"        path="source/meta-openembedded"/>
+  <project remote="yocto"        revision="kirkstone"                                name="meta-security"            path="source/meta-security"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte"          path="source/meta-chargebyte"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="meta-chargebyte-distro"   path="source/meta-chargebyte-distro"/>
+  <project remote="rauc"         revision="2eb0d2af94c63f4bc5b52e5f7c5a36000bfd7016" name="meta-rauc"                path="source/meta-rauc"/>
+  <project remote="qt5"          revision="kirkstone"                                name="meta-qt5"                 path="source/meta-qt5"/>
+  <project remote="nymea"        revision="kirkstone"                                name="meta-nymea"               path="source/meta-nymea"/>
+  <project remote="chargebyte"   revision="kirkstone"                                name="chargebyte-bsp"           path="chargebyte-bsp">
     <linkfile dest="build/conf" src="conf"/>
   </project>
 


### PR DESCRIPTION
Upcoming chargebyte builds will include the nymea stack, so let's add the required layers to the repo checkout.

Bring also the documentation in sync.

(The small whitespace alignment is required for derived none-public repos to cover long-ish internal layer names.)