### PR TITLE
Update Shared State mirror to kirkstone and add Hash Equivalence

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -217,7 +217,9 @@ BB_DISKMON_DIRS ??= "\
 # present in the cache. It assumes you can download something faster than you can build it
 # which will depend on your network.
 #
-SSTATE_MIRRORS ?= "file://.* http://sstate.yoctoproject.org/2.5/PATH;downloadfilename=PATH"
+BB_HASHSERVE ?= "auto"
+BB_HASHSERVE_UPSTREAM ?= "hashserv.yocto.io:8687"
+SSTATE_MIRRORS ?= "file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
 
 #
 # Qemu configuration


### PR DESCRIPTION
This might fix the upstream sstate cache and also make use of upstream hash serve:
https://docs.yoctoproject.org/dev/migration-guides/release-notes-4.0.html
