### PR TITLE
local.conf: remove pci, pcmcia, ptest and vulkan from DISTRO_FEATURES

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -250,7 +250,19 @@ BUILDHISTORY_COMMIT = "1"
 # bit confusing (but perhaps desired) - disable it here:
 BUILD_REPRODUCIBLE_BINARIES = "0"
 
-DISTRO_FEATURES:remove = " x11 wifi bluetooth bluez5 alsa pulseadio gobject-introspection-data"
+DISTRO_FEATURES:remove = " \
+    alsa \
+    bluetooth \
+    bluez5 \
+    gobject-introspection-data \
+    pci \
+    pcmcia \
+    ptest \
+    pulseaudio \
+    vulkan \
+    wifi \
+    x11 \
+"
 
 DISTRO_FEATURES:append = " systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += " sysvinit pulseaudio bluez5 gobject-introspection-data"


### PR DESCRIPTION
For chargebyte platforms, these are not required at the moment which makes the rootfs images a little bit smaller.

While at, sort the list and split it across lines to easier diffs in the future.