### PR TITLE
Add a .gitignore and finetune DISTRO_FEATURES

### DIFF
--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,0 +1,2 @@
+site.conf
+templateconf.cfg

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -260,6 +260,7 @@ DISTRO_FEATURES:remove = " \
     ptest \
     pulseaudio \
     vulkan \
+    wayland \
     wifi \
     x11 \
 "


### PR DESCRIPTION
The gitignore allows easier review of current git state and
wayland is not needed on our platforms.
