### PR TITLE
Add 'origin' alias to all remotes

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,12 +3,12 @@
   <default sync-j="4" revision="kirkstone"/>
 
   <!-- remote repository definitions -->
-  <remote fetch="https://git.yoctoproject.org" name="yocto"/>
-  <remote fetch="https://github.com/openembedded" name="oe"/>
-  <remote fetch="https://github.com/chargebyte" name="chargebyte"/>
-  <remote fetch="https://github.com/rauc" name="rauc"/>
-  <remote fetch="https://github.com/meta-qt5" name="qt5"/>
-  <remote fetch="https://github.com/nymea" name="nymea"/>
+  <remote fetch="https://git.yoctoproject.org" name="yocto" alias="origin"/>
+  <remote fetch="https://github.com/openembedded" name="oe" alias="origin"/>
+  <remote fetch="https://github.com/chargebyte" name="chargebyte" alias="origin"/>
+  <remote fetch="https://github.com/rauc" name="rauc" alias="origin"/>
+  <remote fetch="https://github.com/meta-qt5" name="qt5" alias="origin"/>
+  <remote fetch="https://github.com/nymea" name="nymea" alias="origin"/>
 
   <!-- project definitions -->
   <project remote="yocto"        revision="kirkstone"                                name="poky"                     path="source"/>


### PR DESCRIPTION
See https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.md#Element-remote

Since 'origin' is default value of the remote in usual git clones, this makes (at least my) developer's dayjob easier because you don't have to remember what is the actual remote name.