### PR TITLE
Enable spdx SBoM creation and cve report by default

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -270,6 +270,19 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED += " sysvinit pulseaudio bluez5 gobject-intr
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_update-alternatives = ""
 
+# Enable SPDX SBOM generation
+INHERIT += "create-spdx"
+
+# Optional: nicer JSON formatting
+SPDX_PRETTY = "1"
+
+# Optional: include source descriptions / archives (useful for compliance)
+SPDX_INCLUDE_SOURCES = "1"
+SPDX_ARCHIVE_SOURCES = "1"
+
+# Enable security report generation at build time
+INHERIT += "cve-check"
+
 # /var/log should be persistent
 VOLATILE_LOG_DIR = "no"
 


### PR DESCRIPTION
The enables chargebyte yocto bsp to create the json spdx format based Software Bill of Material in order to be complaint with the CRA.

The resulting `<image-name>.spdx.tar.zst` and `<image-name>.rootfs.cve` can be released together with each release.  